### PR TITLE
Convert Retool.js to use React hooks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import Retool from "./components/Retool";
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 const App = () => {
   const sample = {

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from "react";
 
 const App = () => {
   const sample = {
-    example: "value",
+    name: "value",
     example2: 19999,
     example3: { hello: "world" },
     input: "",
@@ -24,7 +24,7 @@ const App = () => {
   const [retoolData, setRetoolData] = useState("");
   const [data, setData] = useState(sample);
   return (
-    <div style={{ height: "500px" }}>
+    <div>
       <button
         onClick={() => {
           setData({ ...data, example2: "new value" });
@@ -41,8 +41,10 @@ const App = () => {
       <h1> {retoolData} </h1>
       <p id="hello"> {JSON.stringify(data)} </p>
       <Retool
-        url="https://support.retool.com/apps/Ben/parent%20window%20query123"
+        url="https://support.retool.com/embedded/public/cb9e15f0-5d7c-43a7-a746-cdec870dde9a"
         data={data}
+        height="500px"
+        width="500px"
       ></Retool>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -3,9 +3,8 @@ import React, { useState, useEffect } from "react";
 
 const App = () => {
   const sample = {
-    name: "value",
-    example2: 19999,
-    example3: { hello: "world" },
+    example1: "",
+    example2: false,
     input: "",
   };
 
@@ -25,27 +24,31 @@ const App = () => {
   const [data, setData] = useState(sample);
   return (
     <div>
+      <h1> React-Retool</h1>
       <button
         onClick={() => {
-          setData({ ...data, example2: "new value" });
+          setData({ ...data, example2: !data.example2 });
         }}
       >
-        This is button
+        Click me!
       </button>
+      <br />
+      <br />
+      <label> Share something: </label>
       <input
         type="text"
         value={data.input}
         onChange={(e) => setData({ ...data, input: e.target.value })}
       />
-      <p id="hello"> Hey123 </p>
-      <h1> {retoolData} </h1>
-      <p id="hello"> {JSON.stringify(data)} </p>
+      <br />
+      <br />
       <Retool
         url="https://support.retool.com/embedded/public/cb9e15f0-5d7c-43a7-a746-cdec870dde9a"
         data={data}
-        height="500px"
-        width="500px"
+        height="700px"
+        width="1000px"
       ></Retool>
+      <h1> {retoolData} </h1>
     </div>
   );
 };

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,51 @@
-import Retool from "./components/Retool"
+import Retool from "./components/Retool";
+import React, { useState, useEffect } from "react";
 
-function App() {
+const App = () => {
+  const sample = {
+    example: "value",
+    example2: 19999,
+    example3: { hello: "world" },
+    input: "",
+  };
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (event.data?.type !== "PARENT_WINDOW_QUERY") {
+        setRetoolData(event.data);
+      }
+    };
+
+    window.addEventListener("message", handler);
+
+    return () => window.removeEventListener("message", handler);
+  }, []);
+
+  const [retoolData, setRetoolData] = useState("");
+  const [data, setData] = useState(sample);
   return (
-    <Retool
-      url="https://retoolin.tryretool.com/embedded/public/f7607e1f-670a-4ebf-9a09-be54cf17181e"
-      data={{
-        example: "value",
-      }}
-    ></Retool>
-  )
-}
+    <div style={{ height: "500px" }}>
+      <button
+        onClick={() => {
+          setData({ ...data, example2: "new value" });
+        }}
+      >
+        This is button
+      </button>
+      <input
+        type="text"
+        value={data.input}
+        onChange={(e) => setData({ ...data, input: e.target.value })}
+      />
+      <p id="hello"> Hey123 </p>
+      <h1> {retoolData} </h1>
+      <p id="hello"> {JSON.stringify(data)} </p>
+      <Retool
+        url="https://support.retool.com/apps/Ben/parent%20window%20query123"
+        data={data}
+      ></Retool>
+    </div>
+  );
+};
 
-export default App
+export default App;

--- a/src/components/Retool.js
+++ b/src/components/Retool.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const Retool = ({ data, url, height, width }) => {
   const embeddedIframe = useRef(null);

--- a/src/components/Retool.js
+++ b/src/components/Retool.js
@@ -4,6 +4,7 @@ const Retool = ({ data, url, height, width }) => {
   const embeddedIframe = useRef(null);
   const [elementWatchers, setElementWatchers] = useState({});
 
+  /* Retool passes up the list of elements to watch on page load  */
   useEffect(() => {
     for (const key in elementWatchers) {
       const watcher = elementWatchers[key];
@@ -19,7 +20,9 @@ const Retool = ({ data, url, height, width }) => {
     }
   }, [data, elementWatchers]);
 
+  /* On page load, add event listener to listen for events from Retool */
   useEffect(() => {
+    /* Handle events - if PWQ then create/replace watchers -> return result */
     const handler = (event) => {
       if (!embeddedIframe?.current?.contentWindow) return;
       if (event.data.type === "PARENT_WINDOW_QUERY") {
@@ -37,6 +40,7 @@ const Retool = ({ data, url, height, width }) => {
     return () => window.removeEventListener("message", handler);
   }, []);
 
+  /* Creates or updates the list of values for us to watch for changes */
   const createOrReplaceWatcher = (selector, pageName, queryId) => {
     const watcherId = pageName + "-" + queryId;
     const updatedState = elementWatchers;
@@ -51,6 +55,7 @@ const Retool = ({ data, url, height, width }) => {
     setElementWatchers(updatedState);
   };
 
+  /* Checks for selectors for data and posts message for Retool to read */
   const postMessageForSelector = (messageType, eventData) => {
     const maybeData = data[eventData.selector];
 

--- a/src/components/Retool.js
+++ b/src/components/Retool.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 
-const Retool = ({ data, url }) => {
+const Retool = ({ data, url, height, width }) => {
   const embeddedIframe = useRef(null);
   const [elementWatchers, setElementWatchers] = useState({});
 
@@ -34,7 +34,6 @@ const Retool = ({ data, url }) => {
 
     window.addEventListener("message", handler);
 
-    // clean up
     return () => window.removeEventListener("message", handler);
   }, []);
 
@@ -74,8 +73,8 @@ const Retool = ({ data, url }) => {
 
   return (
     <iframe
-      height="100%"
-      width="100%"
+      height={height ?? "100%"}
+      width={width ?? "100%"}
       frameBorder="none"
       src={url}
       ref={embeddedIframe}

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
-import React from "react"
-import ReactDOM from "react-dom"
-import "./index.css"
-import App from "./App"
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
 
 ReactDOM.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
   document.getElementById("root")
-)
+);


### PR DESCRIPTION
- Converts retool.js to use React hooks instead of polling DOM selectors 
- allows for iframe height/width to be passed in as props
- updates the development example