### PR TITLE
Declare a license to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
     "type": "git",
     "url": "git@github.com:tryretool/react-retool.git"
   },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/tryretool/react-retool/blob/main/LICENSE"
+    }
+  ],
   "keywords": [
     "react",
     "react-component",


### PR DESCRIPTION
Declare a license in package.json so it updates our npm homepage https://www.npmjs.com/package/react-retool