### PR TITLE
[fix] handle falsy values

### DIFF
--- a/src/components/Retool.js
+++ b/src/components/Retool.js
@@ -84,7 +84,7 @@ const Retool = ({
   const postMessageForSelector = (messageType, eventData) => {
     const maybeData = data[eventData.selector];
 
-    if (maybeData) {
+    if (maybeData !== undefined) {
       embeddedIframe.current.contentWindow.postMessage(
         {
           type: messageType,


### PR DESCRIPTION
Right now we won't send falsy values from data (`0`, `''`, etc). This fixes it.